### PR TITLE
Update OpenJDK Docker base image to fix CVEs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: true                  # Required to install packages
 
 env:
-  DOCKER_COMPOSE_VERSION: 1.5.1
+  DOCKER_COMPOSE_VERSION: 1.7.1
 
 language: scala
 
@@ -15,6 +15,8 @@ services:
   - docker
 
 before_install:
+  - sudo apt-get update
+  - sudo apt-get install -o Dpkg::Options::="--force-confold" --force-yes -y docker-engine
   - sudo rm /usr/local/bin/docker-compose
   - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
   - chmod +x docker-compose

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.opensource.zalan.do/stups/openjdk:8u77-b03-1-20
+FROM registry.opensource.zalan.do/stups/openjdk:8-26
 MAINTAINER Team Pathfinder <team-pathfinder@zalando.de>
 
 EXPOSE 8080


### PR DESCRIPTION
Update to latest Docker image stups openjdk                   8-26             24m ago stups_stups-go              NO_CVES_FOUND. This is just a "convenience" PR, ignore it if you want (but live with the CVEs) :smirk: