### PR TITLE
Update swagger.yaml

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -73,7 +73,7 @@ paths:
           - routes.read
       summary: A list of available paths.
       parameters:
-        - name: team
+        - name: owned_by_team
           in: query
           type: string
           required: false


### PR DESCRIPTION
GET /paths is expecting `owned_by_team` however in swagger it was `team`.