### PR TITLE
Adds pagination to GET current-routes endpoint

### DIFF
--- a/src/it/scala/org/zalando/spearheads/innkeeper/dao/RoutesPostgresRepoSpec.scala
+++ b/src/it/scala/org/zalando/spearheads/innkeeper/dao/RoutesPostgresRepoSpec.scala
@@ -361,7 +361,10 @@ class RoutesPostgresRepoSpec extends FunSpec with BeforeAndAfter with Matchers w
         deleteRoute(4)
         insertRoute("R5", createdAt = createdAt)
 
-        val routesWithPaths = routesRepo.selectActiveRoutesData(LocalDateTime.now())
+        val routesWithPaths = routesRepo.selectActiveRoutesData(
+          currentTime = LocalDateTime.now(),
+          pagination = None
+        )
 
         routesWithPaths.size should be (2)
 
@@ -380,7 +383,8 @@ class RoutesPostgresRepoSpec extends FunSpec with BeforeAndAfter with Matchers w
         )
 
         val result = routesRepo.selectActiveRoutesData(
-          currentTime = createdAt.plusDays(1L)
+          currentTime = createdAt.plusDays(1L),
+          pagination = None
         )
 
         result.size should be (1)

--- a/src/it/scala/org/zalando/spearheads/innkeeper/routes/GetCurrentRoutesSpec.scala
+++ b/src/it/scala/org/zalando/spearheads/innkeeper/routes/GetCurrentRoutesSpec.scala
@@ -93,6 +93,7 @@ class GetCurrentRoutesSpec extends FunSpec with BeforeAndAfter with Matchers {
 
         response.status should be(StatusCodes.OK)
         response.headers.map(_.name()) should contain("X-Snapshot-Timestamp")
+        response.headers.map(_.name()) should contain("X-Last-Update")
 
         val entity = entityString(response)
         val routes = entity.parseJson.convertTo[Seq[EskipRouteWrapper]]
@@ -115,6 +116,7 @@ class GetCurrentRoutesSpec extends FunSpec with BeforeAndAfter with Matchers {
 
         response.status should be(StatusCodes.OK)
         response.headers.map(_.name()) should contain("X-Snapshot-Timestamp")
+        response.headers.map(_.name()) should contain("X-Last-Update")
 
         val entity = entityString(response)
         val routes = entity.parseJson.convertTo[Seq[EskipRouteWrapper]]

--- a/src/it/scala/org/zalando/spearheads/innkeeper/routes/RoutesSpecsHelper.scala
+++ b/src/it/scala/org/zalando/spearheads/innkeeper/routes/RoutesSpecsHelper.scala
@@ -38,6 +38,9 @@ object RoutesSpecsHelper {
 
   private val currentRoutesUri = s"$baseUri/current-routes"
 
+  def doGetRequest(token: String, path: String, params: Map[String, List[String]] = Map.empty): HttpResponse =
+    doGet(baseUri + path + paramsToUri(params), token)
+
   def postSlashRoutes(route: String)(token: String): HttpResponse = {
 
     val entity = HttpEntity(ContentType(MediaTypes.`application/json`), route)

--- a/src/main/scala/org/zalando/spearheads/innkeeper/Rejections.scala
+++ b/src/main/scala/org/zalando/spearheads/innkeeper/Rejections.scala
@@ -150,4 +150,10 @@ object Rejections {
     def message: String = s"A star path must match the configured patterns:\n${patterns.mkString("\n")}"
     def code: String = "SPP"
   }
+
+  case class CurrentRoutesTimestampRejection(requestDescription: String) extends Rejection with InnkeeperRejection {
+    def statusCode: StatusCode = StatusCodes.BadRequest
+    def message: String = "A paginated request for current routes should include the snapshot-timestamp for non zero offset."
+    def code: String = "CRT"
+  }
 }

--- a/src/main/scala/org/zalando/spearheads/innkeeper/RouteDirectives.scala
+++ b/src/main/scala/org/zalando/spearheads/innkeeper/RouteDirectives.scala
@@ -1,5 +1,7 @@
 package org.zalando.spearheads.innkeeper
 
+import java.time.LocalDateTime
+
 import akka.NotUsed
 import akka.http.scaladsl.model.HttpEntity.ChunkStreamPart
 import akka.http.scaladsl.model.{HttpEntity, HttpResponse, MediaTypes}
@@ -86,6 +88,15 @@ trait RouteDirectives {
           case _                                                         => reject(InternalServerErrorRejection(requestDescription))(ctx)
         }
       }
+    }
+
+  def getLastUpdate(routesService: RoutesService, requestDescription: String)(implicit executionContext: ExecutionContext): Directive1[Option[LocalDateTime]] =
+    Directive[Tuple1[Option[LocalDateTime]]] { inner => ctx => {
+      routesService.getLastUpdate.fast.transformWith {
+        case Success(lastUpdate) => inner(Tuple1(lastUpdate))(ctx)
+        case _                   => reject(InternalServerErrorRejection(requestDescription))(ctx)
+      }
+    }
     }
 
   def chunkedResponseOf[T](jsonService: JsonService)(source: Source[T, NotUsed])(implicit jsonWriter: JsonWriter[T]) = {

--- a/src/main/scala/org/zalando/spearheads/innkeeper/dao/RoutesPostgresRepo.scala
+++ b/src/main/scala/org/zalando/spearheads/innkeeper/dao/RoutesPostgresRepo.scala
@@ -328,4 +328,15 @@ class RoutesPostgresRepo @Inject() (
       selectById(id)
     }
   }
+
+  override def getLastUpdate: Future[Option[LocalDateTime]] = {
+    val query = Routes.map(_.updatedAt)
+      .unionAll(Paths.map(_.updatedAt))
+      .unionAll(DeletedRoutes.map(_.deletedAt))
+      .max
+
+    db.run {
+      query.result
+    }
+  }
 }

--- a/src/main/scala/org/zalando/spearheads/innkeeper/dao/RoutesRepo.scala
+++ b/src/main/scala/org/zalando/spearheads/innkeeper/dao/RoutesRepo.scala
@@ -19,7 +19,7 @@ trait RoutesRepo {
   def selectModifiedSince(since: LocalDateTime, currentTime: LocalDateTime): DatabasePublisher[ModifiedRoute]
   def routeWithNameExists(name: String): Future[Boolean]
 
-  def selectActiveRoutesData(currentTime: LocalDateTime): DatabasePublisher[RouteData]
+  def selectActiveRoutesData(currentTime: LocalDateTime, pagination: Option[Pagination]): DatabasePublisher[RouteData]
 
   def delete(id: Long, deletedBy: Option[String] = None, dateTime: Option[LocalDateTime] = None): Future[Boolean]
   def deleteFiltered(filters: Seq[QueryFilter], dateTime: Option[LocalDateTime]): Future[Seq[Long]]

--- a/src/main/scala/org/zalando/spearheads/innkeeper/dao/RoutesRepo.scala
+++ b/src/main/scala/org/zalando/spearheads/innkeeper/dao/RoutesRepo.scala
@@ -25,4 +25,6 @@ trait RoutesRepo {
   def deleteFiltered(filters: Seq[QueryFilter], dateTime: Option[LocalDateTime]): Future[Seq[Long]]
 
   def update(id: Long, pathPatch: RoutePatch, updatedAt: LocalDateTime): Future[Option[(RouteRow, PathRow)]]
+
+  def getLastUpdate: Future[Option[LocalDateTime]]
 }

--- a/src/main/scala/org/zalando/spearheads/innkeeper/routes/GetCurrentRoutes.scala
+++ b/src/main/scala/org/zalando/spearheads/innkeeper/routes/GetCurrentRoutes.scala
@@ -8,18 +8,22 @@ import akka.http.scaladsl.server.Route
 import com.google.inject.Inject
 import com.typesafe.scalalogging.StrictLogging
 import org.zalando.spearheads.innkeeper.Rejections.CurrentRoutesTimestampRejection
-import org.zalando.spearheads.innkeeper.RouteDirectives.{chunkedResponseOf, extractPagination}
+import org.zalando.spearheads.innkeeper.RouteDirectives.{chunkedResponseOf, extractPagination, getLastUpdate}
 import org.zalando.spearheads.innkeeper.api.JsonProtocols._
 import org.zalando.spearheads.innkeeper.api.{EskipRouteWrapper, JsonService}
 import org.zalando.spearheads.innkeeper.oauth.OAuthDirectives.hasOneOfTheScopes
 import org.zalando.spearheads.innkeeper.oauth.{AuthenticatedUser, Scopes}
-import org.zalando.spearheads.innkeeper.services.EskipRouteService
+import org.zalando.spearheads.innkeeper.services.{EskipRouteService, RoutesService}
+
+import scala.concurrent.ExecutionContext
 
 /**
  * @author dpersa
  */
 class GetCurrentRoutes @Inject() (
+    executionContext: ExecutionContext,
     eskipRouteService: EskipRouteService,
+    routesService: RoutesService,
     jsonService: JsonService,
     scopes: Scopes) extends StrictLogging {
 
@@ -39,15 +43,21 @@ class GetCurrentRoutes @Inject() (
             if (snapshotTimestamp.isEmpty && pagination.exists(_.offset > 0)) {
               reject(CurrentRoutesTimestampRejection(reqDesc))
             } else {
-              val timestamp = snapshotTimestamp.getOrElse(LocalDateTime.now())
+              getLastUpdate(routesService, reqDesc)(executionContext) { lastUpdate =>
+                val timestamp = snapshotTimestamp.getOrElse(LocalDateTime.now())
 
-              mapResponse(response => {
-                val headers = response.headers :+
-                  RawHeader("X-Snapshot-Timestamp", timestamp.toString)
-                response.withHeaders(headers)
-              }) {
-                chunkedResponseOf[EskipRouteWrapper](jsonService) {
-                  eskipRouteService.currentEskipRoutes(timestamp, pagination)
+                mapResponse(response => {
+                  val snapshotTimestampHeader = RawHeader("X-Snapshot-Timestamp", timestamp.toString)
+
+                  val lastUpdateHeader = lastUpdate
+                    .map(timestamp => RawHeader("X-Last-Update", timestamp.toString))
+                    .toSeq
+
+                  response.withHeaders(response.headers ++ lastUpdateHeader :+ snapshotTimestampHeader)
+                }) {
+                  chunkedResponseOf[EskipRouteWrapper](jsonService) {
+                    eskipRouteService.currentEskipRoutes(timestamp, pagination)
+                  }
                 }
               }
             }

--- a/src/main/scala/org/zalando/spearheads/innkeeper/routes/GetCurrentRoutes.scala
+++ b/src/main/scala/org/zalando/spearheads/innkeeper/routes/GetCurrentRoutes.scala
@@ -1,10 +1,14 @@
 package org.zalando.spearheads.innkeeper.routes
 
-import akka.http.scaladsl.server.Directives.get
+import java.time.LocalDateTime
+
+import akka.http.scaladsl.model.headers.RawHeader
+import akka.http.scaladsl.server.Directives.{get, mapResponse, parameterMultiMap, reject}
 import akka.http.scaladsl.server.Route
 import com.google.inject.Inject
 import com.typesafe.scalalogging.StrictLogging
-import org.zalando.spearheads.innkeeper.RouteDirectives.chunkedResponseOf
+import org.zalando.spearheads.innkeeper.Rejections.CurrentRoutesTimestampRejection
+import org.zalando.spearheads.innkeeper.RouteDirectives.{chunkedResponseOf, extractPagination}
 import org.zalando.spearheads.innkeeper.api.JsonProtocols._
 import org.zalando.spearheads.innkeeper.api.{EskipRouteWrapper, JsonService}
 import org.zalando.spearheads.innkeeper.oauth.OAuthDirectives.hasOneOfTheScopes
@@ -24,8 +28,30 @@ class GetCurrentRoutes @Inject() (
       val reqDesc = "get /current-routes"
       hasOneOfTheScopes(authenticatedUser, reqDesc, scopes.READ, scopes.ADMIN) {
         logger.debug(reqDesc)
-        chunkedResponseOf[EskipRouteWrapper](jsonService) {
-          eskipRouteService.currentEskipRoutes()
+
+        parameterMultiMap { parameterMultiMap =>
+          extractPagination(parameterMultiMap) { pagination =>
+            val snapshotTimestamp = parameterMultiMap
+              .get("snapshot-timestamp")
+              .flatMap(_.headOption)
+              .flatMap(RequestParameters.dateTimeParameter)
+
+            if (snapshotTimestamp.isEmpty && pagination.exists(_.offset > 0)) {
+              reject(CurrentRoutesTimestampRejection(reqDesc))
+            } else {
+              val timestamp = snapshotTimestamp.getOrElse(LocalDateTime.now())
+
+              mapResponse(response => {
+                val headers = response.headers :+
+                  RawHeader("X-Snapshot-Timestamp", timestamp.toString)
+                response.withHeaders(headers)
+              }) {
+                chunkedResponseOf[EskipRouteWrapper](jsonService) {
+                  eskipRouteService.currentEskipRoutes(timestamp, pagination)
+                }
+              }
+            }
+          }
         }
       }
     }

--- a/src/main/scala/org/zalando/spearheads/innkeeper/services/EskipRouteService.scala
+++ b/src/main/scala/org/zalando/spearheads/innkeeper/services/EskipRouteService.scala
@@ -20,8 +20,8 @@ class EskipRouteService @Inject() (routesRepo: RoutesRepo, routeToEskipTransform
     }
   }
 
-  def currentEskipRoutes(currentTime: LocalDateTime = LocalDateTime.now()): Source[EskipRouteWrapper, NotUsed] = {
-    val publisher = routesRepo.selectActiveRoutesData(currentTime).mapResult { routeData =>
+  def currentEskipRoutes(currentTime: LocalDateTime, pagination: Option[Pagination]): Source[EskipRouteWrapper, NotUsed] = {
+    val publisher = routesRepo.selectActiveRoutesData(currentTime, pagination).mapResult { routeData =>
       EskipRouteWrapper(
         routeChangeType = RouteChangeType.Create,
         name = RouteName(routeData.name),

--- a/src/main/scala/org/zalando/spearheads/innkeeper/services/RoutesService.scala
+++ b/src/main/scala/org/zalando/spearheads/innkeeper/services/RoutesService.scala
@@ -39,6 +39,8 @@ trait RoutesService {
 
   def findById(id: Long, embed: Set[Embed]): Future[Result[RouteOut]]
 
+  def getLastUpdate: Future[Option[LocalDateTime]]
+
 }
 
 class DefaultRoutesService @Inject() (
@@ -216,4 +218,6 @@ class DefaultRoutesService @Inject() (
       path = path,
       hosts = hosts)
   }
+
+  override def getLastUpdate: Future[Option[LocalDateTime]] = routesRepo.getLastUpdate
 }

--- a/src/test/scala/org/zalando/spearheads/innkeeper/services/EskipRouteServiceSpec.scala
+++ b/src/test/scala/org/zalando/spearheads/innkeeper/services/EskipRouteServiceSpec.scala
@@ -32,16 +32,17 @@ class EskipRouteServiceSpec extends FunSpec with Matchers with MockFactory with 
       describe("when the common filters are enabled") {
 
         it ("should return the correct current routes") {
+          val pagination = None
 
           (routesRepo.selectActiveRoutesData _)
-            .expects(currentTime)
+            .expects(currentTime, pagination)
             .returning(FakeDatabasePublisher(Seq(routeData)))
 
           (routeToEskipTransformer.transform _)
             .expects(routeData)
             .returning(eskipRoute)
 
-          val result = eskipRouteService.currentEskipRoutes(currentTime)
+          val result = eskipRouteService.currentEskipRoutes(currentTime, pagination)
             .runWith(Sink.head).futureValue
 
           verifyRoute(result)
@@ -50,8 +51,10 @@ class EskipRouteServiceSpec extends FunSpec with Matchers with MockFactory with 
 
       describe("when the common filters are not enabled") {
         it ("should return the correct current routes") {
+          val pagination = None
+
           (routesRepo.selectActiveRoutesData _)
-            .expects(currentTime)
+            .expects(currentTime, pagination)
             .returning(FakeDatabasePublisher(Seq(routeData.copy(usesCommonFilters = false))))
 
           val eskipRouteWithoutCommonFilters =
@@ -63,7 +66,7 @@ class EskipRouteServiceSpec extends FunSpec with Matchers with MockFactory with 
             .expects(routeData.copy(usesCommonFilters = false))
             .returning(eskipRouteWithoutCommonFilters)
 
-          val result = eskipRouteService.currentEskipRoutes(currentTime)
+          val result = eskipRouteService.currentEskipRoutes(currentTime, pagination)
             .runWith(Sink.head).futureValue
 
           result.name should be(RouteName(routeName))

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -301,6 +301,26 @@ paths:
         - company:
           - routes.read
       summary: Returns the list of all the active routes.
+      parameters:
+        - name: snapshot-timestamp
+          in: query
+          description: |
+            the timestamp to use for computing the snapshot
+            it is mandatory if offset is present and greater than zero
+          required: false
+          type: string
+          format: date-time
+        - name: limit
+          in: query
+          description: the limit for a paginated query
+          required: false
+          type: int64
+        - name: offset
+          in: query
+          description: |
+            the offset for a paginated query, if missing an limit is present it defaults to 0
+          required: false
+          type: int64
       responses:
         '200':
           description: An array of routes
@@ -308,6 +328,17 @@ paths:
             type: array
             items:
               $ref: '#/definitions/RouteOut'
+          headers:
+            X-Snapshot-Timestamp:
+              type: string
+              format: date-time
+              description: |
+                The timestamp used for computing the snapshot.
+            X-Last-Update:
+              type: string
+              format: date-time
+              description: |
+                The timestamp for the last update to the routes (create, update, delete).
         default:
           description: A processing or an unexpected error.
           schema:


### PR DESCRIPTION
Extra headers/query params are needed for being able to acquire a consistent snapshot of the routes.